### PR TITLE
(maint) add grouped jobs concept and count interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,20 +18,41 @@ scheduling subsystem so that other services don't need to (and avoids potential 
 around multiple services attempting to initialize the same scheduling subystem
 in a single JVM process).
 
-This is a very early release, and provides only the most basic API.  The functions
-that are currently available are as follows:
+The functions that are currently available are as follows:
 
 * `interspaced [interval-ms f]`: schedules a job that will call `f`, block until
   that call completes, sleep for `interval-ms` milliseconds, and then repeat.
   Returns an identifier that can be used to reference this scheduled job (e.g.,
   for cancellation) later.
+* `interspaced [interval-ms f group-id]`: schedules a job that will call `f`, block until
+  that call completes, sleep for `interval-ms` milliseconds, and then repeat.
+  Returns an identifier that can be used to reference this scheduled job (e.g.,
+  for cancellation) later. A group identifier `group-id` can be provided that
+  allows jobs in the same group to be stopped at the same time.
 * `after [interval-ms f]`: schedules a job that will call `f` a single time, after
   a delay of `interval-ms` milliseconds.  Returns an identifier that can be used
   to reference this scheduled job (e.g. for cancellation) later.
+* `after [interval-ms f group-id]`: schedules a job that will call `f` a single time, after
+  a delay of `interval-ms` milliseconds.  Returns an identifier that can be used
+  to reference this scheduled job (e.g. for cancellation) later. A group identifier
+  `group-id` can be provided that allows jobs in the same group to be stopped
+  at the same time.
 * `stop-job [job-id]`: Given a `job-id` returned by one of the previous functions,
   cancels the job.  If the job is currently executing it will be allowed to complete,
   but will not be invoked again afterward.  Returns `true` if the job was successfully
   stopped, `false` otherwise.
+* `stop-grouped-jobs [group-id]`: Given a `group-id` identifier, cancel all the jobs
+  associated with that `group-id`.  If any of the jobs are currently executing they
+  will be allowed to complete, but will not be invoked again afterward.  Returns a
+  sequence of maps, one for each job in the group, with each map containing the
+  `job` and a boolean `stopped?` key indiciating if the job was stopped successfully
+  or not.
+* `count-jobs []`: Return a count of the total number of scheduled jobs known to
+  to the scheduling service.  `after` jobs that have completed won't be included
+  in the total.
+* `count-jobs [group-id]`: Return a count of the total number of scheduled jobs
+  with the associated `group-id` known to to the scheduling service.
+  `after` jobs that have completed won't be included in the total.
 
 ### Implementation Details
 

--- a/src/puppetlabs/trapperkeeper/services/protocols/scheduler.clj
+++ b/src/puppetlabs/trapperkeeper/services/protocols/scheduler.clj
@@ -2,17 +2,40 @@
 
 (defprotocol SchedulerService
 
-  (interspaced [this n f]
+  (interspaced
+    [this n f]
+    [this n f group-id]
     "Calls 'f' repeatedly with a delay of 'n' milliseconds between the
     completion of a given invocation and the beginning of the following
-    invocation.  Returns an identifier for the scheduled job.")
+    invocation.  Returns an identifier for the scheduled job. An optional
+    group-id can be provided to collect a set of jobs into one group to allow
+    them to be stopped together.")
 
-  (after [this n f]
+  (after
+    [this n f]
+    [this n f group-id]
     "Calls 'f' once after a delay of 'n' milliseconds.
-    Returns an identifier for the scheduled job.")
+    Returns an identifier for the scheduled job. An optional
+    group can be provided to associated jobs with each other to allow
+    them to be stopped together.")
 
-  (stop-job [this id]
+  (stop-job [this job]
     "Given an identifier of a scheduled job, stop its execution.  If an
     invocation of the job is currently executing, it will be allowed to
     complete,  but the job will not be invocated again.
-    Returns 'true' if the job was successfully stopped, 'false' otherwise."))
+    Returns 'true' if the job was successfully stopped, 'false' otherwise.")
+
+  (stop-jobs
+    [this]
+    [this group-id]
+    "Stop all the jobs associated with the service.  Given an optional group-id
+    stop only the jobs associated with that group id.
+    Returns a sequence of maps, each with an identifier for the job and a boolean to
+    indicate if the job was stopped successfully.")
+
+  (count-jobs
+    [this]
+    [this group-id]
+    "Return the number of jobs known to the scheduler service, or the number
+    of jobs known to the scheduler service by group id. A nil group-id
+    will return the count of all jobs."))

--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_service.clj
@@ -19,6 +19,45 @@
       (tk/service-context)
       :jobs))
 
+(defn- enqueue-job!
+  ([this id]
+   (enqueue-job! this id {}))
+  ([this id opts]
+   (let [result (assoc opts :job id)]
+    (swap! (get-jobs this) conj result)
+    result)))
+
+(defn- dequeue-job!
+  ([this job]
+    (swap! (get-jobs this) disj job))
+  ([this id keyword]
+    (when-let [item (first (filter #(= id (get % keyword)) @(get-jobs this)))]
+      (swap! (get-jobs this) disj item))))
+
+(defn- after-job
+  "Jobs run with `after` only execute once, and when done need to be reomved from
+  the scheduled jobs set.  This wraps the job's function so that the job is removed
+  correctly from the set when it completes (or fails)."
+  [this after-id f]
+  (fn []
+    (try
+      (f)
+      (finally
+        (dequeue-job! this after-id :after-id)))))
+
+(defn- jobs-by-group-id
+  [this group-id]
+  (if group-id
+    (filter #(= group-id (:group-id %)) @(get-jobs this))
+    @(get-jobs this)))
+
+(defn- create-maybe-stop-job-fn
+  "given a stop-job function, return function that when given a job returns
+  a map with the job and a boolean to indicate if the job was stopped"
+  [stop-fn]
+  (fn [job]
+    {:job job
+    :stopped? (stop-fn job)}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Trapperkeeper service definition
@@ -30,7 +69,8 @@
     (log/debug "Initializing Scheduler Service")
     (let [pool (core/create-pool)]
       (assoc context :pool pool
-                     :jobs (atom #{}))))
+                     :jobs (atom #{})
+                     :after-id (atom 0))))
 
   (stop [this context]
     (log/debug "Shutting down Scheduler Service")
@@ -40,17 +80,42 @@
     context)
 
   (interspaced [this n f]
-    (let [id (core/interspaced n f (get-pool this))]
-      (swap! (get-jobs this) conj id)
-      id))
+    (interspaced this n f nil))
+
+  (interspaced [this n f group-id]
+               (let [id (core/interspaced n f (get-pool this))]
+                 (enqueue-job! this id {:group-id group-id})))
 
   (after [this n f]
-    (let [id (core/after n f (get-pool this))]
-      (swap! (get-jobs this) conj id)
-      id))
+   (after this n f nil))
 
-  (stop-job [this id]
-    (let [result (core/stop-job id (get-pool this))]
-      (when result
-        (swap! (get-jobs this) disj id))
-      result)))
+  (after [this n f group-id]
+     ; use after-id to identify the job for the cleanup "after-job" wrapper
+    (let [after-id (swap! (:after-id (tk/service-context this)) inc)
+          ; wrap the job function in a function that will remove the job from the job set when it is done
+          wrapped-fn (after-job this after-id f)
+          id (core/after n wrapped-fn (get-pool this))]
+      (enqueue-job! this id {:after-id after-id
+                           :group-id   group-id})))
+
+  (stop-job [this job]
+    (let [result (core/stop-job (:job job) (get-pool this))]
+       (dequeue-job! this job)
+       result))
+
+  (stop-jobs
+    [this]
+    (stop-jobs this nil))
+
+  (stop-jobs [this group-id]
+    (let [jobs-by-group (jobs-by-group-id this group-id)]
+       (reduce conj []
+         (map
+           (create-maybe-stop-job-fn (partial stop-job this))
+            jobs-by-group))))
+
+  (count-jobs [this]
+    (count-jobs this nil))
+
+  (count-jobs [this group-id]
+    (count (jobs-by-group-id this group-id))))

--- a/test/integration/puppetlabs/trapperkeeper/services/scheduler/scheduler_service_test.clj
+++ b/test/integration/puppetlabs/trapperkeeper/services/scheduler/scheduler_service_test.clj
@@ -7,53 +7,105 @@
             [overtone.at-at :as at-at]))
 
 (deftest ^:integration test-interspaced
-  (with-app-with-empty-config app [scheduler-service]
-    (testing "interspaced"
-      (let [service (tk/get-service app :SchedulerService)
-            num-runs 3 ; let it run a few times, but not too many
-            interval 300
-            p (promise)
-            counter (atom 0)
-            delays (atom [])
-            last-completion-time (atom nil)
-            job (fn []
-                  (when @last-completion-time
-                    (let [delay (- (System/currentTimeMillis) @last-completion-time)]
-                      (swap! delays conj delay)))
-                  (swap! counter inc)
+  (testing "without group-id"
+    (with-app-with-empty-config app [scheduler-service]
+      (testing "interspaced"
+        (let [service (tk/get-service app :SchedulerService)
+              num-runs 3 ; let it run a few times, but not too many
+              interval 300
+              p (promise)
+              counter (atom 0)
+              delays (atom [])
+              last-completion-time (atom nil)
+              job (fn []
+                    (when @last-completion-time
+                      (let [delay (- (System/currentTimeMillis) @last-completion-time)]
+                        (swap! delays conj delay)))
+                    (swap! counter inc)
 
-                  ; Make this job take a while so we can measure the duration
-                  ; between invocations and ensure that the next invocation is
-                  ; not scheduled until this one completes.
-                  (Thread/sleep 100)
+                    ; Make this job take a while so we can measure the duration
+                    ; between invocations and ensure that the next invocation is
+                    ; not scheduled until this one completes.
+                    (Thread/sleep 100)
 
-                  ; The test is over!
-                  (when (= @counter num-runs)
-                    (deliver p nil))
+                    ; The test is over!
+                    (when (= @counter num-runs)
+                      (deliver p nil))
 
-                  (reset! last-completion-time (System/currentTimeMillis)))]
+                    (reset! last-completion-time (System/currentTimeMillis)))]
 
-        ; Schedule the job, and wait for it run num-runs times, then stop it.
-        (let [job-id (interspaced service interval job)]
-          (deref p)
-          (stop-job service job-id))
+          ; Schedule the job, and wait for it run num-runs times, then stop it.
+          (let [job-id (interspaced service interval job)]
+            (deref p)
+            (stop-job service job-id))
 
-        (testing (str "Each delay should be at least " interval "ms")
-          (is (every? (fn [delay] (>= delay interval)) @delays)))))))
+          (testing (str "Each delay should be at least " interval "ms")
+            (is (every? (fn [delay] (>= delay interval)) @delays)))))))
+
+  (testing "with group-id"
+    (with-app-with-empty-config app [scheduler-service]
+      (testing "interspaced"
+        (let [group-id :some-group-identifier
+              service (tk/get-service app :SchedulerService)
+              num-runs 3 ; let it run a few times, but not too many
+              interval 300
+              p (promise)
+              counter (atom 0)
+              delays (atom [])
+              last-completion-time (atom nil)
+              job (fn []
+                    (when @last-completion-time
+                      (let [delay (- (System/currentTimeMillis) @last-completion-time)]
+                        (swap! delays conj delay)))
+                    (swap! counter inc)
+
+                    ; Make this job take a while so we can measure the duration
+                    ; between invocations and ensure that the next invocation is
+                    ; not scheduled until this one completes.
+                    (Thread/sleep 100)
+
+                    ; The test is over!
+                    (when (= @counter num-runs)
+                      (deliver p nil))
+
+                    (reset! last-completion-time (System/currentTimeMillis)))]
+
+          ; Schedule the job, and wait for it run num-runs times, then stop it.
+          (let [job-id (interspaced service interval job group-id)]
+            (deref p)
+            (stop-job service job-id))
+
+          (testing (str "Each delay should be at least " interval "ms")
+            (is (every? (fn [delay] (>= delay interval)) @delays))))))))
 
 (deftest ^:integration test-after
-  (with-app-with-empty-config app [scheduler-service]
-    (testing "after"
-      (let [delay 100]
-        (testing "should execute at least " delay " milliseconds in the future"
-          (let [completed (promise)
-                job #(deliver completed (System/currentTimeMillis))
-                service (tk/get-service app :SchedulerService)]
-            (let [schedule-time (System/currentTimeMillis)]
-              (after service delay job)
-              (let [execution-time (deref completed)
-                    actual-delay (- execution-time schedule-time)]
-                (is (>= actual-delay delay))))))))))
+  (testing "without group-id"
+    (with-app-with-empty-config app [scheduler-service]
+      (testing "after"
+        (let [delay 100]
+          (testing "should execute at least " delay " milliseconds in the future"
+            (let [completed (promise)
+                  job #(deliver completed (System/currentTimeMillis))
+                  service (tk/get-service app :SchedulerService)]
+              (let [schedule-time (System/currentTimeMillis)]
+                (after service delay job)
+                (let [execution-time (deref completed)
+                      actual-delay (- execution-time schedule-time)]
+                  (is (>= actual-delay delay))))))))))
+
+  (testing "with group-id"
+    (with-app-with-empty-config app [scheduler-service]
+      (testing "after"
+        (let [delay 100]
+          (testing "should execute at least " delay " milliseconds in the future"
+            (let [completed (promise)
+                  job #(deliver completed (System/currentTimeMillis))
+                  service (tk/get-service app :SchedulerService)]
+              (let [schedule-time (System/currentTimeMillis)]
+                (after service delay job :some-group-identifier)
+                (let [execution-time (deref completed)
+                      actual-delay (- execution-time schedule-time)]
+                  (is (>= actual-delay delay)))))))))))
 
 ; This test has a race condition, but it is very unlikley to occur in reality,
 ; and so far it's actually been impossible to get this test to fail due to a
@@ -62,37 +114,195 @@
 ; at all in this case, primarily due to the fact that the underlying scheduler
 ; library (at-at) has no tests of its own.  :(
 (deftest ^:integration test-stop-job
-  (testing "stop-job lets a job complete but does not run it again"
+  (testing "without group-id"
+    (testing "stop-job lets a job complete but does not run it again"
+      (with-app-with-empty-config app [scheduler-service]
+        (let [service (tk/get-service app :SchedulerService)
+              started (promise)
+              stopped (promise)
+              start-time (atom 0)
+              completed (promise)
+              job (fn []
+                    (reset! start-time (System/currentTimeMillis))
+                    (deliver started nil)
+                    (deref stopped)
+                    (deliver completed nil))
+              interval 10
+              job-id (interspaced service interval job)]
+          ; wait for the job to start
+          (deref started)
+          (let [original-start-time @start-time]
+            (testing "the job can be stopped"
+              (is (stop-job service job-id)))
+            (deliver stopped nil)
+            (deref completed)
+            ; wait a bit, ensure the job does not run again
+            (testing "the job should not run again"
+              (Thread/sleep 100)
+              (is (= original-start-time @start-time)))
+            (testing "there should be no other jobs running"
+              (is (= 0 (count @(get-jobs service))))))))))
+  (testing "with group-id"
+    (testing "stop-job lets a job complete but does not run it again"
+      (with-app-with-empty-config app [scheduler-service]
+        (let [service (tk/get-service app :SchedulerService)
+              started (promise)
+              stopped (promise)
+              start-time (atom 0)
+              completed (promise)
+              job (fn []
+                    (reset! start-time (System/currentTimeMillis))
+                    (deliver started nil)
+                    (deref stopped)
+                    (deliver completed nil))
+              interval 10
+              job-id (interspaced service interval job :some-group-identifier)]
+          ; wait for the job to start
+          (deref started)
+          (let [original-start-time @start-time]
+            (testing "the job can be stopped"
+              (is (stop-job service job-id)))
+            (deliver stopped nil)
+            (deref completed)
+            ; wait a bit, ensure the job does not run again
+            (testing "the job should not run again"
+              (Thread/sleep 100)
+              (is (= original-start-time @start-time)))
+            (testing "there should be no other jobs running"
+              (is (= 0 (count @(get-jobs service)))))))))))
+
+(defn guaranteed-start-interval-job
+  ([service interval]
+    (guaranteed-start-interval-job service interval nil))
+
+  ([service interval group-id]
+   (let [started (promise)
+         job (fn []
+               (deliver started nil))
+         result (interspaced service interval job group-id)]
+     (deref started)
+     result)))
+
+; This test has a few race conditions, but unlikely to occur in reality
+(deftest ^:integration test-count-job
+  (testing "count-jobs shows correct number of non-group-id jobs"
+    (with-app-with-empty-config app [scheduler-service]
+      (let [service (tk/get-service app :SchedulerService)
+            interval 10
+            job-0 (guaranteed-start-interval-job service interval)]
+        (is (= 1 (count-jobs service)))
+        (let [job-1 (guaranteed-start-interval-job service interval)]
+          (is (= 2 (count-jobs service))
+          (let [job-2 (guaranteed-start-interval-job service interval)]
+            (is (= 3 (count-jobs service)))
+            (stop-job service job-0)
+            (is (= 2 (count-jobs service)))
+            (stop-job service job-1)
+            (is (= 1 (count-jobs service)))
+            (stop-job service job-2)
+            (is (= 0 (count-jobs service)))))))))
+
+  (testing "count-jobs shows correct number of group-id and non-group-id jobs"
+    (with-app-with-empty-config app [scheduler-service]
+      (let [service (tk/get-service app :SchedulerService)
+            interval 10
+            job-0 (guaranteed-start-interval-job service interval)
+            group-id :unique-group-id]
+        (is (= 1 (count-jobs service)))
+        (let [group-id-job-0 (guaranteed-start-interval-job service interval group-id)]
+          (is (= 2 (count-jobs service)))
+          (is (= 1 (count-jobs service group-id)))
+          (let [job-1 (guaranteed-start-interval-job service interval)]
+            (is (= 3 (count-jobs service)))
+            (is (= 1 (count-jobs service group-id)))
+              (let [group-id-job-1 (guaranteed-start-interval-job service interval group-id)]
+                (is (= 4 (count-jobs service)))
+                (is (= 2 (count-jobs service group-id)))
+                (let [job-2 (guaranteed-start-interval-job service interval)]
+                  (is (= 5 (count-jobs service)))
+                  (is (= 2 (count-jobs service group-id)))
+                  (stop-job service job-0)
+                  (is (= 4 (count-jobs service)))
+                  (is (= 2 (count-jobs service group-id)))
+                  (stop-job service group-id-job-0)
+                  (is (= 3 (count-jobs service)))
+                  (is (= 1 (count-jobs service group-id)))
+                  (stop-job service job-1)
+                  (is (= 2 (count-jobs service)))
+                  (is (= 1 (count-jobs service group-id)))
+                  (stop-job service group-id-job-1)
+                  (is (= 1 (count-jobs service)))
+                  (is (= 0 (count-jobs service group-id)))
+                  (stop-job service job-2)
+                  (is (= 0 (count-jobs service)))
+                  (is (= 0 (count-jobs service group-id))))))))))
+
+  (testing "after reduces count when complete"
+    (with-app-with-empty-config app [scheduler-service]
+      (let [service (tk/get-service app :SchedulerService)
+            delay 100
+            wait-for-start (promise)
+            completed (promise)
+            job (fn []
+                  (deref wait-for-start)
+                  (deliver completed (System/currentTimeMillis)))]
+        (after service delay job)
+        (is (= 1 (count-jobs service)))
+        (deliver wait-for-start true)
+        (deref completed)
+        ; there is a small window between when the promise is delivered and the count changes
+        (Thread/sleep 100)
+        (is (= 0 (count-jobs service)))))))
+
+(deftest ^:integration test-stop-grouped-jobs
+  (testing "stop-jobs stops the jobs for a group"
     (with-app-with-empty-config app [scheduler-service]
       (let [service (tk/get-service app :SchedulerService)
             started (promise)
-            stopped (promise)
-            start-time (atom 0)
-            completed (promise)
             job (fn []
-                  (reset! start-time (System/currentTimeMillis))
-                  (deliver started nil)
-                  (deref stopped)
-                  (deliver completed nil))
-            job-id (interspaced service 10 job)]
-        ; wait for the job to start
+                  (deliver started nil))
+            interval 10
+            group-id-0 :unique-group-id
+            group-id-1 :more-unique-group-id
+            ; create one job without a group-id and two with one group-id
+            ; and a third with a different group-id
+            job-3 (interspaced service interval (constantly true))
+            job-2 (interspaced service interval (constantly true) group-id-0)
+            job-1 (interspaced service interval (constantly true) group-id-0)
+            job-0 (interspaced service interval job group-id-1)]
+
+        (testing "all the jobs were started"
+          (is (= 4 (count-jobs service)))
+          (is (= 2 (count-jobs service group-id-0)))
+          (is (= 1 (count-jobs service group-id-1))))
+
+        ; wait for the jobs to start
         (deref started)
-        (let [original-start-time @start-time]
-          (testing "the job can be stopped"
-            (is (stop-job service job-id)))
-          (deliver stopped nil)
-          (deref completed)
-          ; wait a bit, ensure the job does not run again
-          (testing "the job should not run again"
-            (Thread/sleep 100)
-            (is (= original-start-time @start-time))))))))
+        (Thread/sleep 100)
+        (testing "stopping one group-id does not stop them all"
+          (stop-jobs service group-id-0)
+          (is (= 2 (count-jobs service)))
+          (is (= 0 (count-jobs service group-id-0)))
+          (is (= 1 (count-jobs service group-id-1))))
+
+        (testing "stopping one job does not stop the group id based job"
+          (stop-job service job-3)
+          (is (= 1 (count-jobs service)))
+          (is (= 0 (count-jobs service group-id-0)))
+          (is (= 1 (count-jobs service group-id-1))))
+
+        (testing "stopping by group id stops the job"
+          (stop-jobs service group-id-1))
+          (is (= 0 (count-jobs service)))
+          (is (= 0 (count-jobs service group-id-0)))
+          (is (= 0 (count-jobs service group-id-1)))))))
 
 (defn schedule-random-jobs
-  "Schedules several random jobs and returns their IDs."
+  "Schedules several random jobs and returns their at/at IDs."
   [service]
   (set
     (for [x [1 2 3]]
-      (interspaced service 1000 (constantly x)))))
+      (:job (interspaced service 1000 (constantly x))))))
 
 ; In the future, it might be reasonable to add a function like this into the
 ; scheduler service protocol.  If so, this function can be deleted.


### PR DESCRIPTION
This adds the concept of jobs within the same group.  Jobs that are grouped
can be counted or stopped together.  This is helpful when managing jobs associated
with a given trapperkeeper service.

Upon service stop, the jobs set is now emptied.  Previously the jobs were stopped
but the set maintained the entries in the set.

`after` calls are now given a unique identifier and removed from the set when they
complete.