### PR TITLE
(maint) add CHANGELOG for 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.1.0
+ * Add the concept of group-id to the job creation endpoints to allow
+ jobs to be grouped together for listing and cancellation.
+ * Fix a potential memory leak with jobs created using `after`
+ * Add an interface to return the total number of jobs and the number
+ of jobs in a group-id
+
+## 0.0.1
+ * Initial release


### PR DESCRIPTION
Add a changelog file and comments about the new group-id features
as well as the fix for the `after` memory leak.