### PR TITLE
(MAINT) Avoid a null pointer exception during an early shutdown

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_service.clj
@@ -75,7 +75,8 @@
   (stop [this context]
     (log/debug "Shutting down Scheduler Service")
     ; Stop any jobs that are still running
-    (core/stop-all-jobs! @(:jobs context) (get-pool this))
+    (when-let [jobs (:jobs context)]
+      (core/stop-all-jobs! @jobs (get-pool this)))
     (log/debug "Scheduler Service shutdown complete.")
     context)
 


### PR DESCRIPTION
Previously, if a startup error were encountered before the
scheduler service's init function was called, a call to the
stop function could throw/log a NullPointerException when trying
to access state that had not been set on the context during the
init call.

With this commit, the scheduler service just avoids the code
which would access the context state that doesn't exist,
avoiding the appearance of the NullPointerException.