### PR TITLE
(maint) remove dependency on c3p0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]
-                 [org.quartz-scheduler/quartz "2.2.3"]]
+                 [org.quartz-scheduler/quartz "2.2.3" :exclusions [c3p0]]]
 
   :min-lein-version "2.7.1"
 


### PR DESCRIPTION
c3p0 is included by quartz by default, but the connection pool isn't
used by this service.  c3p0 has a different license.