### PR TITLE
(PE-25398) add interval and interval-after interfaces and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+ * add interface for `interval` and `interval-after` to the
+ protocol and implementation to allow regular cadance jobs.
+ * add support for thread-count configuration value that defaults to 10
+
 ## 1.0.1
  * exclude c3p0 from dependencies, it isn't used.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ The functions that are currently available are as follows:
   Returns an identifier that can be used to reference this scheduled job (e.g.,
   for cancellation) later. A group identifier `group-id` can be provided that
   allows jobs in the same group to be stopped at the same time.
+* `interval [interval-ms f]`: schedules a job that will call `f`, block until
+  that call completes, and then run again at the next logical interval based on
+  `interval-ms` and the original start time.  In other words, `f` will get called every
+  `interval-ms` unless the execution time for `f` exceeds `interval-ms` in which case
+  that execution is skipped.
+  Returns an identifier that can be used to reference this scheduled job (e.g.,
+  for cancellation) later.
+* `interval [interval-ms f group-id]`: schedules a job that will call `f`, block until
+  that call completes, and then run again at the next logical interval based on
+  `interval-ms` and the original start time.  In other words, `f` will get called every
+  `interval-ms` unless the execution time for `f` exceeds `interval-ms` in which case
+  that execution is skipped. If there are insufficient threads in the thread pool to
+  run the interval job at the time of execution, the job will be skipped. Returns an
+  identifier that can be used to reference this scheduled job (e.g.,
+  for cancellation) later. A group identifier `group-id` can be provided that
+  allows jobs in the same group to be stopped at the same time.
 * `after [interval-ms f]`: schedules a job that will call `f` a single time, after
   a delay of `interval-ms` milliseconds.  Returns an identifier that can be used
   to reference this scheduled job (e.g. for cancellation) later.
@@ -37,6 +53,11 @@ The functions that are currently available are as follows:
   to reference this scheduled job (e.g. for cancellation) later. A group identifier
   `group-id` can be provided that allows jobs in the same group to be stopped
   at the same time.
+* `interval-after [initial-delay-ms interval-ms f]`: Similar to `interval` but delays
+  initial execution until `initial-delay-ms` has occurred.
+* `interval-after [initial-delay-ms interval-ms f group-id]`:Similar to `interval` but delays
+  initial execution until `initial-delay-ms` has occurred A group identifier `group-id` can be provided that
+  allows jobs in the same group to be stopped at the same time.
 * `stop-job [job-id]`: Given a `job-id` returned by one of the previous functions,
   cancels the job.  If the job is currently executing it will be allowed to complete,
   but will not be invoked again afterward.  Returns `true` if the job was successfully
@@ -59,12 +80,16 @@ The functions that are currently available are as follows:
 
 ### Implementation Details
 
+A configuration value is available under scheduler->thread-count that controls
+the number of threads used internally by the quartz library for job scheduling.
+If not specified, it defaults to 10, which is the quartz internal default.
+
 The current implementation of the `SchedulerService` is a wrapper around
 the [`org.quartz-scheduler/quartz`](http://www.quartz-scheduler.org/) library.
 
 ### What's Next?
 
-* Add additional scheduling API functions, e.g. `every`.
+* Add additional scheduling API functions with more complicated recurring models.`.
 * Add API for introspecting the state of currently scheduled jobs
 
 #Support

--- a/src/puppetlabs/trapperkeeper/services/protocols/scheduler.clj
+++ b/src/puppetlabs/trapperkeeper/services/protocols/scheduler.clj
@@ -19,6 +19,26 @@
     group can be provided to associated jobs with each other to allow
     them to be stopped together.")
 
+  (interval
+    [this n f]
+    [this n f group-id]
+   "Calls 'f' repeatedly with a delay of 'n' milliseconds between the
+    beginning of a given invocation and the beginning of the following
+    invocation. If an invocation executon time is longer than the interval,
+    the subsquent invocation is skipped.
+    Returns an identifier for the scheduled job. An optional
+    group-id can be provided to collect a set of jobs into one group to allow
+    them to be stopped together.")
+
+  (interval-after
+    [this initial-delay repeat-delay f]
+    [this initial-delay repeat-delay f group-id]
+    "Calls 'f' repeatedly with a delay of 'repeat-delay' milliseconds after the `initial-delay` in millseconds.
+    Returns an identifier for the scheduled job. An optional
+    group-id can be provided to collect a set of jobs into one group to allow
+    them to be stopped together.")
+
+
   (stop-job [this job]
     "Given an identifier of a scheduled job, stop its execution.  If an
     invocation of the job is currently executing, it will be allowed to

--- a/src/puppetlabs/trapperkeeper/services/scheduler/job.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/job.clj
@@ -15,6 +15,25 @@
   []
   [[] (atom {})])
 
+(defn- recurring?
+  [options]
+  (or (contains? options :interval) (contains? options :interspaced)))
+
+(defn- calculate-next-execution-time
+  [context options]
+  (if (contains? options :interspaced)
+    (Date. ^Long (+ (System/currentTimeMillis) (:interspaced options)))
+    (.getFireTimeAfter (.getTrigger context) (Date.))))
+
+(defn- should-skip?
+  [context options]
+  (when (contains? options :interval)
+    (let [interval-ms (:interval options)
+          now-ms (System/currentTimeMillis)
+          scheduled-fire-time-ms (.getTime (.getScheduledFireTime context))]
+      ; if the scheduled execution time is an interval or more away, skip it.
+      (> now-ms (+ scheduled-fire-time-ms interval-ms)))))
+
 (defn -execute
   [this ^JobExecutionContext context]
   (try
@@ -22,19 +41,26 @@
           options (.get merged "jobData")
           f (:job options)]
       (swap! (.state this) into {:current-thread (Thread/currentThread)})
-      (f)
+
+      (if-not (should-skip? context options)
+        (f)
+        (log/info (i18n/trs "Skipping execution of job {0} because of missed interval." (.toString (.getKey (.getJobDetail context))))))
+
       ; using quartz interval execution does not take into account the
-      ; execution time of the actual job.  If that is important, we
-      ; manually trigger the job after the interval.
-      (when (contains? options :interval)
-        (let [interval (:interval options)
-              scheduler (.getScheduler context)
+      ; execution time of the actual job.  For interspaced jobs, this means
+      ; triggering the job after this one completes, for interval jobs,
+      ; this means fast-forwarding the execution time to the next logical
+      ; one
+      (when (recurring? options)
+        (let [scheduler (.getScheduler context)
               oldTrigger (.getTrigger context)
-              future-date (Date. ^Long (+ (System/currentTimeMillis) interval))
+              future-date (calculate-next-execution-time context options)
               trigger (-> (.getTriggerBuilder oldTrigger)
                           (.startAt future-date)
                           (.build))]
           (.rescheduleJob scheduler (.getKey oldTrigger) trigger))))
+
+
     (catch Throwable e
       (log/error e (i18n/trs "scheduled job threw error"))
       (let [new-exception (JobExecutionException. ^Throwable e)]

--- a/test/integration/puppetlabs/trapperkeeper/services/scheduler/scheduler_service_test.clj
+++ b/test/integration/puppetlabs/trapperkeeper/services/scheduler/scheduler_service_test.clj
@@ -5,7 +5,8 @@
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-service :refer :all]
             [puppetlabs.trapperkeeper.services.protocols.scheduler :refer :all]
             [puppetlabs.trapperkeeper.services.scheduler.scheduler-core :as sc]
-            [puppetlabs.trapperkeeper.app :as tk]))
+            [puppetlabs.trapperkeeper.app :as tk])
+  (:import [java.util.concurrent TimeUnit CountDownLatch]))
 
 (deftest ^:integration test-interspaced
   (testing "without group-id"
@@ -303,7 +304,7 @@
           (is (= 0 (count-jobs service group-id-0)))
           (is (= 0 (count-jobs service group-id-1))))))))
 
-(defn schedule-random-jobs
+(defn schedule-random-interspaced-jobs
   "Schedules several random jobs and returns their JobKeys."
   [service]
   (set
@@ -314,7 +315,7 @@
   (testing "Any remaining jobs will be stopped when the service is stopped."
     (let [app (bootstrap-services-with-empty-config [scheduler-service])
           service (tk/get-service app :SchedulerService)
-          job-ids (schedule-random-jobs service)]
+          job-ids (schedule-random-interspaced-jobs service)]
 
       (testing "reports all of the jobs we just scheduled"
         (is (= (set job-ids) (set (get-jobs service)))))
@@ -344,6 +345,293 @@
           (is (not= :timeout (ks/with-timeout 10 :timeout (tk/stop app))))
           (is (empty? (get-jobs service))))
         (deref job-done)))))
+
+(defn distances
+  "Calculate the distances between each item in a sequence."
+  [v]
+  (map #(- %2 %1) v (rest v)))
+
+;; define some acceptable bounded accuracy ratings.
+;; as the jvm warms up, the accuracy increases
+(def accuracy-high 15)
+(def accuracy-low -15)
+
+(deftest ^:integration test-interval
+  (let [num-runs 10] ; let it run a few times, but not too many
+    (testing "when recurring is > wait-time"
+      (doseq [[recurring-delay wait-time] [[500 100] [250 100] [233 200]]]
+        (let [expected-delta (- recurring-delay wait-time)]
+          (testing (str "testing recurring-delay " recurring-delay " wait time " wait-time)
+            (testing "subsequent delays are observed"
+              (with-app-with-empty-config app [scheduler-service]
+                (let [service (tk/get-service app :SchedulerService)
+                      counter (atom 0)
+                      stop-job-promise (promise)
+                      delays (atom [])
+                      start-times (atom [])
+                      last-completion-time (atom nil)
+                      job (fn []
+                            (let [local-counter (swap! counter inc)
+                                  start-time (System/currentTimeMillis)]
+                              (when @last-completion-time
+                                (let [delay (- start-time @last-completion-time)]
+                                  (swap! delays conj delay)))
+
+                              (swap! start-times conj start-time)
+
+                              (Thread/sleep wait-time)
+                              ; The test is over!
+                              (when (= local-counter num-runs)
+                                (deliver stop-job-promise nil))
+
+                              (reset! last-completion-time (System/currentTimeMillis))))
+                      job-start-time (System/currentTimeMillis)
+                      job-id (interval service recurring-delay job)]
+                    (deref stop-job-promise)
+                    (stop-job service job-id)
+                    ; all the jobs should be stopped
+                    (is (= 0 (count-jobs service)))
+                    (testing (str "Each delay should be at less than " wait-time "ms (within accuracy bounds)")
+                      ; time between executions - expected time between executions should be in accuracy range
+                      (is (every? (fn [delay] (< accuracy-low (- delay expected-delta) accuracy-high)) @delays))
+                      ; time between starting points of recurring task
+                      (is (every? (fn [difference]  (< accuracy-low (- recurring-delay difference) accuracy-high)) (distances @start-times)))))))))))
+
+    (testing "when recurring < wait-time"
+      (doseq [[recurring-delay wait-time expected-delta] [[100 333 67] [100 250 50] [100 2330 70]]]
+        (testing (str "testing recurring-delay " recurring-delay " wait time " wait-time)
+          (testing "subsequent delays are observed"
+            (with-app-with-empty-config app [scheduler-service]
+              (let [service (tk/get-service app :SchedulerService)
+                    counter (atom 0)
+                    stop-job-promise (promise)
+                    delays (atom [])
+                    start-times (atom [])
+                    last-completion-time (atom nil)
+                    job (fn []
+                          (let [local-counter (swap! counter inc)
+                                start-time (System/currentTimeMillis)]
+                            (when @last-completion-time
+                              (let [delay (- start-time @last-completion-time)]
+                                (swap! delays conj delay)))
+                            (swap! start-times conj start-time)
+
+                            (Thread/sleep wait-time)
+
+                            ; The test is over!
+                            (when (= local-counter num-runs)
+                              (deliver stop-job-promise nil))
+
+                            (reset! last-completion-time (System/currentTimeMillis))))
+                    job-id (interval service recurring-delay job)]
+                (deref stop-job-promise)
+                (stop-job service job-id)
+                ; all the jobs should be stopped
+                (is (= 0 (count-jobs service)))
+
+                (testing (str "Each delay should be at less than " expected-delta "ms (within accuracy bounds)")
+                ; time between executions - expected time between executions should be in accuracy range
+                  (is (every? (fn [delay] (< accuracy-low (- delay expected-delta) accuracy-high)) @delays))
+                  ; time between starting points of recurring task
+                  (is (every? (fn [difference]  (< accuracy-low (- (+ wait-time expected-delta) difference) accuracy-high)) (distances @start-times))))))))))))
+
+
+(deftest ^:integration test-interval-after
+  (let [num-runs 10]
+    (doseq [[initial-delay recurring-delay wait-time] [[333 500 100] [1000 250 100] [20 233 200]]]
+      (let [expected-delta (- recurring-delay wait-time)]
+        (testing (str "testing initial-delay " initial-delay "recurring-delay " recurring-delay " wait time " wait-time)
+          (testing "initial delay is correctly observed and subsequent delays are observed"
+            (with-app-with-empty-config app [scheduler-service]
+              (let [service (tk/get-service app :SchedulerService)
+                    counter (atom 0)
+                    stop-job-promise (promise)
+                    first-completed-timestamp (promise)
+                    delays (atom [])
+                    start-times (atom [])
+                    last-completion-time (atom nil)
+                    job (fn []
+                          (let [local-counter (swap! counter inc)
+                                start-time (System/currentTimeMillis)]
+                            (when (= 1 local-counter)
+                              (deliver first-completed-timestamp start-time))
+                            (when @last-completion-time
+                              (let [delay (- start-time @last-completion-time)]
+                                (swap! delays conj delay)))
+
+                            (swap! start-times conj start-time)
+
+                            (Thread/sleep wait-time)
+
+                            ; The test is over!
+                            (when (= local-counter num-runs)
+                              (deliver stop-job-promise nil))
+
+                            (reset! last-completion-time (System/currentTimeMillis))))
+                    job-start-time (System/currentTimeMillis)
+                    job-id (interval-after service initial-delay recurring-delay job)
+                    result (deref first-completed-timestamp)]
+                  (is (<= initial-delay (- result job-start-time)))
+                  (deref stop-job-promise)
+                  (stop-job service job-id)
+                  ; all the jobs should be stopped
+                  (is (= 0 (count-jobs service)))
+                  (testing (str "Each delay should be at less than " wait-time "ms (within accuracy bounds)")
+                    ; time between executions - expected time between executions should be in accuracy range
+                    (is (every? (fn [delay] (< accuracy-low (- delay expected-delta) accuracy-high)) @delays))
+                    ; time between starting points of recurring task
+                    (is (every? (fn [difference]  (< accuracy-low (- recurring-delay difference) accuracy-high)) (distances @start-times)))))))
+
+          (testing "initial delay is correctly  observed and subsequent delays are observed with group"
+            (with-app-with-empty-config app [scheduler-service]
+              (let [service (tk/get-service app :SchedulerService)
+                    counter (atom 0)
+                    stop-job-promise (promise)
+                    first-completed-timestamp (promise)
+                    delays (atom [])
+                    start-times (atom [])
+                    last-completion-time (atom nil)
+                    group-id :unique-group-id
+                    job (fn []
+                          (let [local-counter (swap! counter inc)
+                                start-time (System/currentTimeMillis)]
+                            (when (= 1 local-counter)
+                              (deliver first-completed-timestamp start-time))
+                            (when @last-completion-time
+                              (let [delay (- start-time @last-completion-time)]
+                                (swap! delays conj delay)))
+
+                            (swap! start-times conj start-time)
+
+                            (Thread/sleep wait-time)
+
+                            ; The test is over!
+                            (when (= local-counter num-runs)
+                              (deliver stop-job-promise nil))
+
+                            (reset! last-completion-time (System/currentTimeMillis))))
+                    job-start-time (System/currentTimeMillis)
+                    job-id (interval-after service initial-delay recurring-delay job group-id)
+                    result (deref first-completed-timestamp)]
+                  (is (<= initial-delay (- result job-start-time)))
+                  (deref stop-job-promise)
+                  (stop-jobs service group-id)
+                  ;; all the jobs should be stopped
+                  (is (= 0 (count-jobs service)))
+                  (testing (str "Each delay should be at less than " wait-time "ms (within accuracy bounds)")
+                    ; time to recur - time between executions - expected time between executions
+                    (is (every? (fn [delay] (< accuracy-low (- delay expected-delta) accuracy-high)) @delays))
+                    ; time between starting points of recurring task
+                    (is (every? (fn [difference] (< accuracy-low (- recurring-delay difference) accuracy-high)) (distances @start-times))))))))))))
+
+(deftest ^:integration test-thread-starvation
+  ; override the default to set the number of thread-pool threads
+  (let [initial-thread-count 1]
+    (with-app-with-config app [scheduler-service] {:scheduler {:thread-count initial-thread-count}}
+      (let [service (tk/get-service app :SchedulerService)]
+        (testing "after"
+          (testing "all jobs execute, even if delayed"
+            (let [num-jobs 20
+                  delay 100
+                  execution-latch (CountDownLatch. num-jobs)
+                  wait-time 500
+                  release-the-hounds (promise)
+                  count (atom 0)
+                  start-times (atom [])
+                  job (fn []
+                        (deref release-the-hounds)
+                        (swap! start-times conj (System/currentTimeMillis))
+                        (Thread/sleep wait-time)
+                        (swap! count inc)
+                        (.countDown execution-latch))]
+              (doseq [job-index (range 0 num-jobs)]
+                (after service delay job))
+              ;; allow the jobs to run once they are all set up
+              (deliver release-the-hounds true)
+              (is (.await execution-latch 20 TimeUnit/SECONDS))
+              (is (= num-jobs @count))
+              (is (every? (fn [difference] (<= wait-time difference (+ wait-time accuracy-high))) (distances @start-times))))))
+        (testing "interspaced"
+          (testing "all jobs execute at least once before they run again"
+            ;; this demonstrates that previously ready jobs are favored over rescheduled jobs
+            (let [num-jobs 20
+                  frequency 100
+                  execution-latch (CountDownLatch. (* 3 num-jobs))
+                  wait-time 250
+                  release-the-hounds (promise)
+                  run-count (atom 0)
+                  executed-jobs (atom [])
+                  create-identified-job (fn [id]
+                                          (fn []
+                                            (deref release-the-hounds)
+                                            (swap! executed-jobs conj id)
+                                            (Thread/sleep wait-time)
+                                            (swap! run-count inc)
+                                            (.countDown execution-latch)))]
+              (doseq [job-index (range 0 num-jobs)]
+                (interspaced service frequency (create-identified-job job-index)))
+              ;; allow the jobs to run once they are all set up
+              (deliver release-the-hounds true)
+              (is (.await execution-latch 20 TimeUnit/SECONDS))
+              ;; first 20 should be unique
+              (is (= 20 (count (distinct (take 20 @executed-jobs)))))
+              ;; second 20 should be unique
+              (is (= 20 (count (distinct (take 20 (drop 20 @executed-jobs))))))
+              ;; third 20 should be unique
+              (is (= 20 (count (distinct (take 20 (drop 40 @executed-jobs))))))
+              (stop-jobs service))))
+        (testing "interval"
+          (testing "interval jobs can starve other jobs"
+            ;; run 20 interval jobs starting about the same time (incremental times), with a wait time longer than the execution period
+            ;; with only one thread only one job should run successfully every time, the others should be starved out
+            (let [num-jobs 20
+                  frequency 100
+                  execution-latch (CountDownLatch. (* 3 num-jobs))
+                  wait-time 250
+                  release-the-hounds (promise)
+                  run-count (atom 0)
+                  executed-jobs (atom [])
+                  create-identified-job (fn [id]
+                                          (fn []
+                                            (deref release-the-hounds)
+                                            (swap! executed-jobs conj id)
+                                            (Thread/sleep wait-time)
+                                            (swap! run-count inc)
+                                            (.countDown execution-latch)))]
+              (doseq [job-index (range 0 num-jobs)]
+                (interval service frequency (create-identified-job job-index)))
+              ;; allow the jobs to run once they are all set up
+              (deliver release-the-hounds true)
+              (is (.await execution-latch 20 TimeUnit/SECONDS))
+              (is (= 1 (count (distinct @executed-jobs))))
+              (stop-jobs service))))
+        (testing "Interval job correctly skips execution if thread is unavailable"
+          (let [num-jobs 3
+                execution-count (atom 0)
+                start-times (atom [])
+                stop-test (promise)
+                ; interval should run immediately, and then every 100 ms
+                interval-frequency 100
+                ; wait 50ms for the after
+                after-start-time 50
+                after-sleep-time 500
+                ; calculate the next logical interval time
+                effective-first-time (* (quot (+ after-start-time after-sleep-time interval-frequency) interval-frequency) interval-frequency)
+                interval-job (fn []
+                               (swap! start-times conj (System/currentTimeMillis))
+                               (if (= num-jobs (swap! execution-count inc))
+                                  (deliver stop-test true)))
+                after-job (fn []
+                            (Thread/sleep after-sleep-time))]
+            (interval service interval-frequency interval-job)
+            (after service after-start-time after-job)
+            ; wait for the right number of interval jobs to execute
+            (deref stop-test)
+            (stop-jobs service)
+            ; the distance between the first two should be next interval of after-start-time + after-sleep time
+            (is (<= (+ effective-first-time accuracy-low) (first (distances @start-times)) (+ effective-first-time accuracy-high)))
+            ; the next run should be about the interval frequency
+            (is (<= (+ interval-frequency accuracy-low) (nth (distances @start-times) 1) (+ interval-frequency accuracy-high)))))))))
 
 
 


### PR DESCRIPTION
This adds two new behaviors to the scheduler:  `interval` and `interval-after`.  The difference between `interval` and `interspaced` is the cadence of the function execution.  With `interval`, the function is called every `n` milliseconds unless the function execution time exceeds that period.  With `interspaced`, the subsequent function call is `n` milliseconds after the function completes.

`interval-after` delays the initial execution by a specific amount before beginning the recurring behavior.

The README is updated to reflect the new interface, and the changelog updated for release.