### PR TITLE
(PE-25389) update error threshold, document misfire uses

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
@@ -70,6 +70,8 @@
           job (build-executable-job f job-name group-name {:interval repeat-delay})
           schedule (-> (SimpleScheduleBuilder/simpleSchedule)
                        (.withIntervalInMilliseconds repeat-delay)
+                       ; allow quartz to reschedule things outside "org.quartz.jobStore.misfireThreshold" using internal logic
+                       ; this isn't sufficient for short interval jobs, so additional scheduling logic is included in the job itself
                        (.withMisfireHandlingInstructionNextWithRemainingCount)
                        (.repeatForever))
 
@@ -90,6 +92,8 @@
           job (build-executable-job f job-name group-name {:interval repeat-delay})
           schedule (-> (SimpleScheduleBuilder/simpleSchedule)
                        (.withIntervalInMilliseconds repeat-delay)
+                       ; allow quartz to reschedule things outside "org.quartz.jobStore.misfireThreshold" using internal logic
+                       ; this isn't sufficient for short interval jobs, so additional scheduling logic is included in the job itself
                        (.withMisfireHandlingInstructionNextWithRemainingCount)
                        (.repeatForever))
           future-date (Date. ^Long (+ (System/currentTimeMillis) initial-delay))

--- a/test/integration/puppetlabs/trapperkeeper/services/scheduler/scheduler_service_test.clj
+++ b/test/integration/puppetlabs/trapperkeeper/services/scheduler/scheduler_service_test.clj
@@ -353,7 +353,7 @@
 
 ;; define some acceptable bounded accuracy ratings.
 ;; as the jvm warms up, the accuracy increases
-(def accuracy-high 15)
+(def accuracy-high 50)
 (def accuracy-low -15)
 
 (deftest ^:integration test-interval
@@ -632,6 +632,3 @@
             (is (<= (+ effective-first-time accuracy-low) (first (distances @start-times)) (+ effective-first-time accuracy-high)))
             ; the next run should be about the interval frequency
             (is (<= (+ interval-frequency accuracy-low) (nth (distances @start-times) 1) (+ interval-frequency accuracy-high)))))))))
-
-
-


### PR DESCRIPTION
In CI, the error threshold is quite a bit larger than local runs.
This updates the high end threshold to help CI.

In addition, some additional comments were added to explain
the misfire behavior calls added for interval jobs.