### PR TITLE
(maint) Use unique scheduler rather than default scheduler & update deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                  [puppetlabs/trapperkeeper]
                  [puppetlabs/i18n]
                  [puppetlabs/kitchensink]
-                 [org.quartz-scheduler/quartz "2.2.3" :exclusions [c3p0]]]
+                 [org.quartz-scheduler/quartz "2.3.1" :exclusions [c3p0]]]
 
   :min-lein-version "2.9.1"
 

--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,9 @@
                  [puppetlabs/kitchensink]
                  [org.quartz-scheduler/quartz "2.2.3" :exclusions [c3p0]]]
 
-  :min-lein-version "2.7.1"
+  :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "1.7.13"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.0.4"]
                    :inherit [:managed-dependencies]}
 
   :pedantic? :abort
@@ -28,7 +28,7 @@
                    :dependencies [[puppetlabs/trapperkeeper :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink :classifier "test" :scope "test"]]}}
 
-  :plugins  [[lein-parent "0.3.1"]
+  :plugins  [[lein-parent "0.3.7"]
              [puppetlabs/i18n "0.8.0"]]
   :aot [puppetlabs.trapperkeeper.services.scheduler.job]
   :repl-options {:init-ns user})

--- a/src/puppetlabs/trapperkeeper/services/scheduler/job.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/job.clj
@@ -1,8 +1,8 @@
 (ns puppetlabs.trapperkeeper.services.scheduler.job
   (:gen-class
    :name puppetlabs.trapperkeeper.services.scheduler.job
-   :state "state"
-   :init "init"
+   :state state
+   :init init
    :constructors {[] []}
    :implements [org.quartz.StatefulJob org.quartz.InterruptableJob]
    :prefix "-")


### PR DESCRIPTION
I don't know if this (a3d662d) is really desired. Looking for feedback on both the valuableness of this as well as approach and quality. The generic dependencies (4b0a6c3) update is good and should probably be done regardless of the other commits. I have no idea if the quartz update (2dc17b8) is a good thing though, I've just been updating everything.