### PR TITLE
(maint) Help clj find correct StdScheduleFactory constructor

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
@@ -7,7 +7,7 @@
            (org.quartz JobBuilder SimpleScheduleBuilder TriggerBuilder DateBuilder
                        DateBuilder$IntervalUnit Scheduler JobKey SchedulerException JobDataMap)
            (org.quartz.utils Key)
-           (java.util Date UUID)))
+           (java.util Date UUID Properties)))
 
 (def shutdown-timeout-sec 30)
 
@@ -21,7 +21,7 @@
         props (.clone (System/getProperties))
         _ (doseq [[k v] config]
             (.setProperty props k v))
-        factory (StdSchedulerFactory. props)
+        factory (StdSchedulerFactory. ^Properties props)
         scheduler (.getScheduler factory)]
     (.start scheduler)
     scheduler))


### PR DESCRIPTION
When reloading this service on Java 11 clojure can no longer find the
class to load.

The single arity constructor is overloaded for this factory, which
frankly is the only thing I could think of to change shy of reverting
the original commit. It seems to work for me locally.