### PR TITLE
(maint) Help clj find correct StdScheduleFactory constructor

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
@@ -7,7 +7,7 @@
            (org.quartz JobBuilder SimpleScheduleBuilder TriggerBuilder DateBuilder
                        DateBuilder$IntervalUnit Scheduler JobKey SchedulerException JobDataMap)
            (org.quartz.utils Key)
-           (java.util Date UUID)))
+           (java.util Date UUID Properties)))
 
 (def shutdown-timeout-sec 30)
 
@@ -21,7 +21,7 @@
         props (.clone (System/getProperties))
         _ (doseq [[k v] config]
             (.setProperty props k v))
-        factory (StdSchedulerFactory. props)
+        factory (StdSchedulerFactory. ^Properties props)
         scheduler (.getScheduler factory)]
     (.start scheduler)
     scheduler))


### PR DESCRIPTION
Clojure finds classes and constructors using Java's Class.forName with
an explicit classloader. Which classloader that is however is determined
dynamically within clojure.lang.RT.baseLoader().

The single arity constructor is overloaded for this factory, and without
a compiler hint it appears that on reload the wrong classloader is
requested to load this factory.