### PR TITLE
(PE-38419) Add cron date query

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The functions that are currently available are as follows:
   be used to reference this scheduled job (e.g. for cancellation) later. A group identifier
   `group-id` can be provided that allows jobs in the same group to be stopped at the same time.
   More information on a valid cron string can be found [here](https://www.quartz-scheduler.org/api/2.3.0/org/quartz/CronExpression.html).
+* `cron-next-valid-time [cron-string date]`: Given a cron specification and a date, returns a 
+  date that corresponds to the next execution of the timer based on that cron value.
 * `after [interval-ms f]`: schedules a job that will call `f` a single time, after
   a delay of `interval-ms` milliseconds.  Returns an identifier that can be used
   to reference this scheduled job (e.g. for cancellation) later.

--- a/src/puppetlabs/trapperkeeper/services/protocols/scheduler.clj
+++ b/src/puppetlabs/trapperkeeper/services/protocols/scheduler.clj
@@ -10,7 +10,7 @@
     invocation.  Returns an identifier for the scheduled job. An optional
     group-id can be provided to collect a set of jobs into one group to allow
     them to be stopped together.")
-  
+
   (cron
    [this cron-string f]
    [this cron-string f group-id]
@@ -45,6 +45,11 @@
     Returns an identifier for the scheduled job. An optional
     group-id can be provided to collect a set of jobs into one group to allow
     them to be stopped together.")
+
+  (cron-next-valid-time
+   [this cron-string date] 
+   "Given a cron specification and a date, returns a date that corresponds
+    to the next execution of the timer based on that cron value")
 
 
   (stop-job [this job]

--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_core.clj
@@ -136,6 +136,20 @@
       ; this can occur if the interface is being used while the scheduler is shutdown
       (log/error e (i18n/trs "Failed to schedule job")))))
 
+(defn cron-next-valid-time
+  "Returns the next occurance of the cron specification after the given date"
+  [cron-string ^Date date] 
+  (try
+    ;; throws parse error if cron-string is invalid
+    (CronExpression/validateExpression cron-string)
+    (let [cron-expression (CronExpression. cron-string)
+          next-valid-time (.getNextValidTimeAfter cron-expression date)]
+      next-valid-time)
+    (catch java.text.ParseException  e
+      ;; this occurs when the cron-string is invalid
+      (log/debug e)
+      (throw (IllegalArgumentException. ^String (i18n/trs "Invalid cron expression") e)))))
+
 (defn stop-job
   "Returns true, if the job was deleted, and false if the job wasn't found."
   [^JobKey id ^Scheduler scheduler]

--- a/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/scheduler/scheduler_service.clj
@@ -60,6 +60,9 @@
   
   (cron [this cron-string f group-id]
         (core/cron cron-string f (get-scheduler this) (safe-group-id group-id)))
+  
+  (cron-next-valid-time [this cron-string date]
+        (core/cron-next-valid-time cron-string date))
 
   (after [this n f]
    (after this n f default-group-name))


### PR DESCRIPTION
In order to implement blackout windows for advanced patching, we must be able to find the next execution of a cron specification to help understand when blackout windows occur.